### PR TITLE
Potential fix for code scanning alert no. 7: For loop variable changed in body

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,15 +30,19 @@ int main(int argc, char* argv[]) {
   fuse_args.push_back(argv[0]);
 
   // Parse args: keep normal FUSE args; extract --root
-  for (int i = 1; i < argc; ++i) {
+  int i = 1;
+  while (i < argc) {
     if (std::strncmp(argv[i], "--root=", 7) == 0) {
       std::string raw = argv[i] + 7;
       root = rstrip_slash(util::expand_args(raw));
+      ++i;
     } else if (std::strcmp(argv[i], "--root") == 0 && i + 1 < argc) {
-      std::string raw = argv[++i];
+      std::string raw = argv[i + 1];
       root = rstrip_slash(util::expand_args(raw));
+      i += 2;
     } else {
       fuse_args.push_back(argv[i]);
+      ++i;
     }
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/luthfihakim2004/LeichFS/security/code-scanning/7](https://github.com/luthfihakim2004/LeichFS/security/code-scanning/7)

The suggested fix is to replace the `for` loop that iterates over the arguments with a `while` loop, where `i` is incremented manually except in cases where it needs to be manually increased inside the body, as for handling the `--root` argument case. This change makes it explicit where and how `i` is incremented, preventing accidental double-increment and making the loop logic clear. Only the argument parsing loop (lines 33–43) is affected; other code does not need to change. No new imports or functions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
